### PR TITLE
fix: stabilize sanity workflows and meet RedHat AAP requirements

### DIFF
--- a/.github/workflows/ansible-test-sanity.yml
+++ b/.github/workflows/ansible-test-sanity.yml
@@ -29,6 +29,10 @@ jobs:
         include:
           - ansible: "2.16"
             python_ver: "3.11"
+          # RedHat AAP requires the minimum supported ansible-core (2.16)
+          # to be verified against Python 3.12.
+          - ansible: "2.16"
+            python_ver: "3.12"
           - ansible: "2.17"
             python_ver: "3.11"
           - ansible: "2.18"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,10 @@ jobs:
         include:
           - ansible: "2.16"
             python_ver: "3.11"
+          # RedHat AAP requires the minimum supported ansible-core (2.16)
+          # to be verified against Python 3.12.
+          - ansible: "2.16"
+            python_ver: "3.12"
           - ansible: "2.17"
             python_ver: "3.11"
           - ansible: "2.18"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Zscaler Private Access (ZPA) Ansible Collection Changelog
 
+## 2.2.1 (June 1, 2026)
+
+### Notes
+
+- Python Versions: **v3.10, v3.11, v3.12**
+
+### Internals
+
+- [#95](https://github.com/zscaler/zpacloud-ansible/pull/95) - Fixed sanity CI so the matrix-pinned `ansible-core` is installed after `poetry install` (preventing an unintended upgrade that broke `validate-modules`), bumped `requires_ansible` to `>=2.16.0`, added a `2.16`/Python 3.12 sanity job and `ignore-2.20.txt`, and corrected the README license badge URL.
+
 ## 2.2.0 (May, 29 2026)
 
 ### Notes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,13 @@
   - `make test:unit`
 - Prefer focused tests that validate create/update/delete/idempotency/check-mode/error handling.
 
+## CI / Sanity Requirements (Mandatory)
+- `meta/runtime.yml` must declare `requires_ansible: ">=2.16.0"` (RedHat AAP minimum). Keep the CI matrix aligned: test `ansible-core` 2.16+ and verify the minimum version (2.16) against **Python 3.12**.
+- For **every** Ansible version in the CI matrix there must be a matching `tests/sanity/ignore-2.XX.txt`. Adding a new matrix row (e.g. `2.20`) without the corresponding ignore file makes `validate-modules` fail every module with `missing-gplv3-license`.
+- In the sanity/release workflows, install the matrix-pinned `ansible-core` **after** `poetry install`, using `poetry run pip install --force-reinstall --no-deps "<stable-tarball>"`. Because `pyproject.toml` pins `ansible-core = "*"`, running `poetry install` after the pin would upgrade ansible-core to the newest release (e.g. 2.21 on Python 3.12) and break sanity.
+- Run sanity the way RedHat recommends before submitting: `ansible-test sanity --docker default --python 3.12`. The `WARNING: ... virtual environments are out-of-date ...` line is benign (cached venvs rebuild); only `ERROR:`/`FATAL:` lines or a non-zero exit indicate a real failure.
+- README links must be absolute GitHub URLs (Automation Hub does not resolve relative paths); the license badge must point to `https://github.com/zscaler/zpacloud-ansible/blob/master/LICENSE`.
+
 ## API Nuances
 - When API-required fields can be safely inferred (for example, known default resources), resolve them automatically to minimize user friction.
 - For onboarding flows requiring secondary API verification, call the corresponding SDK verification endpoint inside module execution.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Ansible Lint](https://github.com/zscaler/zpacloud-ansible/actions/workflows/ansible-test-lint.yml/badge.svg?branch=master)](https://github.com/zscaler/zpacloud-ansible/actions/workflows/ansible-test-lint.yml)
 [![sanity](https://github.com/zscaler/zpacloud-ansible/actions/workflows/ansible-test-sanity.yml/badge.svg?branch=master)](https://github.com/zscaler/zpacloud-ansible/actions/workflows/ansible-test-sanity.yml)
 [![Documentation Status](https://readthedocs.org/projects/zpacloud-ansible/badge/?version=latest)](https://zpacloud-ansible.readthedocs.io/en/latest/?badge=latest)
-[![License](https://img.shields.io/github/license/zscaler/zpacloud-ansible?color=blue)](https://github.com/zscaler/zpacloud-ansible/v2/blob/master/LICENSE)
+[![License](https://img.shields.io/github/license/zscaler/zpacloud-ansible?color=blue)](https://github.com/zscaler/zpacloud-ansible/blob/master/LICENSE)
 [![Zscaler Community](https://img.shields.io/badge/zscaler-community-blue)](https://community.zscaler.com/)
 
 ## Zscaler Support

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -9,6 +9,22 @@ Releases
 Zscaler Private Access (ZPA) Ansible Collection Changelog
 ---------------------------------------------------------
 
+Version 2.2.1
+==============
+
+2.2.1 (June 1, 2026)
+----------------------------
+
+Notes
+-----
+
+- Python Versions: **v3.10, v3.11, v3.12**
+
+Internals
+---------
+
+* (`#95 <https://github.com/zscaler/zpacloud-ansible/pull/95>`_) - Fixed sanity CI so the matrix-pinned ``ansible-core`` is installed after ``poetry install`` (preventing an unintended upgrade that broke ``validate-modules``), bumped ``requires_ansible`` to ``>=2.16.0``, added a ``2.16``/Python 3.12 sanity job and ``ignore-2.20.txt``, and corrected the README license badge URL.
+
 Version 2.2.0
 ==============
 

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: ">=2.15.0"
+requires_ansible: ">=2.16.0"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3674,14 +3674,14 @@ six = "*"
 
 [[package]]
 name = "typer"
-version = "0.26.3"
+version = "0.26.5"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "typer-0.26.3-py3-none-any.whl", hash = "sha256:e70549ec5a403ca8a0bf0802ddd9f3c6ff7a14ccbb859b01b697baa943636f33"},
-    {file = "typer-0.26.3.tar.gz", hash = "sha256:3e2b9352f535e5303ef27806dadc2c8647687bdca5c902f03fec3fb88f46a46a"},
+    {file = "typer-0.26.5-py3-none-any.whl", hash = "sha256:4bfd901d564e41608920134aa5d4481200f4ba76d98e982d9f9d32dcb7b84da0"},
+    {file = "typer-0.26.5.tar.gz", hash = "sha256:9b9b39e35c3afc9e1e51a06f21155246e457c0911279b09b35d8210ca74b935c"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
- Install matrix-pinned ansible-core after Installing dependencies from lock file

No dependencies to install or update (--force-reinstall --no-deps) so sanity runs as the labeled version instead of being upgraded to 2.21 on py3.12, which broke validate-modules (missing-gplv3-license)
- Bump requires_ansible to >=2.16.0 and add a 2.16/Python 3.12 sanity job
- zpacloud: add tests/sanity/ignore-2.20.txt; fix pep8 E501 in zpa_client.py
- Move release docs job off unsupported Python 3.9 -> 3.11
- Fix README license badge 404 (/v2/ path) and convert relative CONTRIBUTING.md / CHANGELOG.md links to absolute GitHub URLs
- Update CHANGELOG, release_notes.rst, and CLAUDE.md (ziacloud #121, zpacloud #95)

# Contributing

At this time we are not accepting contributions, but we welcome suggestions on how to improve this Collection and feature requests, which can then be added in future releases. These suggestions must be submitted via support ticket using Zscaler support.

~> **NOTE** Pull Requests submitted via this repository will not be responded.

## Zscaler Support

-> **Disclaimer:** Please refer to our [General Support Statement](https://zscaler.github.io/zpacloud-ansible/support.html) before proceeding with the use of this collection. You can also refer to our [troubleshooting guide](https://zscaler.github.io/zpacloud-ansible/troubleshooting.html) for guidance on typical problems.
